### PR TITLE
Bugfix: Deletion of additional data when moving image

### DIFF
--- a/joomadditionalimagefields.php
+++ b/joomadditionalimagefields.php
@@ -195,7 +195,9 @@ class plgJoomGalleryJoomAdditionalImageFields extends JPlugin
    */
   public function onContentAfterSave($context, &$table, $isNew)
   {
-    if(!isset($table->id) || !$table->id || $context != _JOOM_OPTION.'.image')
+    $task = JFactory::getApplication()->input->get('task');
+
+    if(!isset($table->id) || !$table->id || $context != _JOOM_OPTION.'.image' || $task == 'move')
     {
       return;
     }


### PR DESCRIPTION
If PR#78 (https://github.com/JoomGalleryfriends/JoomGallery/pull/78) is applied, the event onContentAfterSave() will be executed even for the task: move. That means that this plugin will be executed when moving an image.
But since moving an image do not pass any form data of the image in the request, this plugin shows a strange behavior: All additional fields data of the moved image gets deleted.

With this PR the plugin will not be performed anymore when moving an image and therefore no additional fields data gets lost anymore.